### PR TITLE
Add Assign Group to Application to AppInstanceClient 

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,16 @@
+## Install the library dependencies
+
+### Python dendencies
+```bash
+pip install  -e .
+```
+
+### Node dependencies
+```bash
+npm install
+```
+
+## Run all tests
+```bash
+npm run test
+```

--- a/okta/AppInstanceClient.py
+++ b/okta/AppInstanceClient.py
@@ -1,6 +1,7 @@
 from okta.framework.ApiClient import ApiClient
 from okta.framework.Utils import Utils
 from okta.framework.PagedResults import PagedResults
+from okta.models.app.AppGroup import AppGroup
 from okta.models.app.AppInstance import AppInstance
 
 
@@ -122,3 +123,15 @@ class AppInstanceClient(ApiClient):
         :return: None
         """
         ApiClient.post_path(self, '/{0}/lifecycle/deactivate'.format(id), None)
+
+    def assign_group_to_app_instance(self, id, group_id):
+        """Assigns a group to an application
+
+        :param id: the target app id
+        :type id: str
+        :param group_id: the target group id
+        :type id: str
+        :rtype: AppGroup
+        """
+        response = ApiClient.put_path(self, '/{0}/groups/{1}'.format(id, group_id))
+        return Utils.deserialize(response.text, AppGroup)


### PR DESCRIPTION
[Assign an Okta application to an okta user group whenever a Voxy organization is created](https://app.asana.com/0/263746924223149/1123259995747143/f)

Reference: [Assign Group to Application REST API](https://developer.okta.com/docs/api/resources/apps/#assign-group-to-application)

**Code review instructions:**
1) Install okta on local:
```bash
cd  ~/workspace/okta-sdk-python && pip install  -e .
```
2) Go to iterative python:
```bash
ipython
```
3) Assign a group to an application:
```python
from okta import AppInstanceClient

OKTA_URL = 'https://voxy.oktapreview.com'
OKTA_API_TOKEN = '00glc0c3dyNJ2Mu8Z_w1Yy_pO-9Awb223domA_KrpO'
OKTA_DEVELOPMENT_APP = '0oakpidpxsUm4LLwQ0h7'
client = AppInstanceClient(OKTA_URL, OKTA_API_TOKEN)

client.assign_group_to_app_instance(id=OKTA_DEVELOPMENT_APP, group_id='OKTA_USER_GROUP_ID')
```
### Screenshots:
<img width="2243" alt="Screen Shot 2019-05-20 at 16 20 53" src="https://user-images.githubusercontent.com/3177703/58046307-485e8c00-7b1b-11e9-9cfe-ec52ab572211.png">
<img width="904" alt="Screen Shot 2019-05-20 at 16 20 38" src="https://user-images.githubusercontent.com/3177703/58046308-485e8c00-7b1b-11e9-9cca-e5dfde5a1270.png">
