### PR TITLE
Add a convenience function for deleting a user from a group

### DIFF
--- a/okta/UserGroupsClient.py
+++ b/okta/UserGroupsClient.py
@@ -133,3 +133,14 @@ class UserGroupsClient(ApiClient):
         :return: None
         """
         response = ApiClient.put_path(self, '/{0}/users/{1}'.format(gid, uid))
+
+    def remove_user_from_group_by_id(self, gid, uid):
+        """Remove a user from a group
+
+        :param gid: the target group id
+        :type gid: str
+        :param uid: the target user id
+        :type uid: str
+        :return: None
+        """
+        return ApiClient.delete_path(self, '/{0}/users/{1}'.format(gid, uid))


### PR DESCRIPTION
Strangely enough, this SDK doesn't have a function for this already. Need it for this story:

https://voxy.atlassian.net/browse/VOXY-732

To reproduce:

In the browser:
1. Open Okta at https://voxy.oktapreview.com
2. Navigate to Directory -> People and click on a test user
3. Make note of the Okta user ID in the URL (the last item in the path); keep this page open
4. Click on a group they are associated with (should be named voxy.stage.{something}), then make note of the group ID in the URL (last item in the path)

In the terminal at `workspace/okta-sdk-python`:
1. `git fetch && git co remove-user-from-group`
2. Open your Python interpreter
3. Use the new function with the IDs retrieved above
```python
from okta import UserGroupsClient
OKTA_URL = 'https://voxy.oktapreview.com'
OKTA_API_TOKEN = '00glc0c3dyNJ2Mu8Z_w1Yy_pO-9Awb223domA_KrpO'
group_id = <the stored Okta group ID>
user_id = <the stored Okta user ID>
client = UserGroupsClient(OKTA_URL, OKTA_API_TOKEN)
response = client.remove_user_from_group_by_id(group_id, user_id)
# response should evaluate to <Response [204]>
# response.text should be empty
# response.status_code should be 204
```

In the browser, refresh the Okta user page and confirm that the selected group is no longer listed in their profile.