### PR TITLE
VOXY-1480 allow parameterized max_attempts, defaulting to 1 so no retries by default

### DIFF
--- a/okta/__init__.py
+++ b/okta/__init__.py
@@ -7,7 +7,7 @@
     :license: Apache 2, see LICENSE.txt for more details.
 """
 
-__version__ = 'v1.0.0'
+__version__ = 'v1.0.1'
 
 from .AppInstanceClient import AppInstanceClient
 from .AuthClient import AuthClient

--- a/okta/framework/ApiClient.py
+++ b/okta/framework/ApiClient.py
@@ -27,6 +27,8 @@ class ApiClient(object):
             raise ValueError('An api_token must be provied to create an ApiClient')
 
         self.api_version = 1
+
+        # pass max_attempts arg with value > 1 to allow that many automatic attempts per request to Okta
         self.max_attempts = kwargs.get('max_attempts', 1)
 
         self.headers = {

--- a/okta/framework/ApiClient.py
+++ b/okta/framework/ApiClient.py
@@ -27,7 +27,7 @@ class ApiClient(object):
             raise ValueError('An api_token must be provied to create an ApiClient')
 
         self.api_version = 1
-        self.max_attempts = 4
+        self.max_attempts = kwargs.get('max_attempts', 1)
 
         self.headers = {
             'Accept': 'application/json',


### PR DESCRIPTION
https://voxy.atlassian.net/browse/VOXY-1480

With this change, the default behavior for requests sent to Okta using the Okta SDK will not automatically retry by default, but will allow passing a `max_attempts` argument to modify that behavior for each new client instantiated.